### PR TITLE
Added sendSingleLikeProxy method. It is w/a for ZBXNEXT-1285

### DIFF
--- a/pyZabbixSender.py
+++ b/pyZabbixSender.py
@@ -320,6 +320,28 @@ class pyZabbixSender:
         to_send = json.dumps(sender_data)
         return self.__send(to_send)
 
+    def sendSingleLikeProxy(self, host, key, value, clock=None, proxy=""):
+        '''
+        #####Description:
+        Use this method to put the data for host monitored by proxy server. This method emulates proxy protocol and data will be accepted by Zabbix server
+        even if they were send not actually from proxy.
+        The following JSON will be send: {"request":"history data","host":"Zabbix proxy","data":[{"host":"<monitored_host_name>","key":"<trapper key>","<value>"}]}
+        #####Parameters:
+        It shares the same parameters as the *addData* method and another one to specify proxy name: proxy=""
+        #####Example:
+        sendStatus = z.sendSingleLikeProxy("myhost.domain.com","trap.cp.avail","110","","MyZabbix proxy")
+
+        '''
+        sender_data = {
+            "request": "history data",
+            "host": proxy,
+            "data": [],
+        }
+
+        obj = self.__createDataPoint(host, key, value, clock)
+        sender_data['data'].append(obj)
+        to_send = json.dumps(sender_data)
+        return self.__send(to_send)
 
         
 #####################################


### PR DESCRIPTION
It is not possible to send data with zabbix_sender for the host monitored by proxy from any other server - only through the Proxy, because the server will only accept history from the proxy that it has been configured to be monitored through. See https://support.zabbix.com/browse/ZBXNEXT-1285
However when looked here: http://zabbix.org/wiki/Docs/protocols I was able to put my history data I want for that host into the appropriate JSON format, open a tcp connection to the server and send it, immitating the proxy

So I added sendSingleLikeProxy method
